### PR TITLE
Put the proper commands into the warning dialog.

### DIFF
--- a/Support/bin/redcarpet.rb
+++ b/Support/bin/redcarpet.rb
@@ -25,19 +25,10 @@ rescue LoadError
   <div class="error">
   <h2>Please install the following gems on your system Ruby</h2>
 
-  <h3>Step 1: Install the required gems</h3>
   <pre><code>
-  sudo gem install redcarpet -v 2.3.0
-  sudo gem install pygments.rb
+  sudo /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/gem install redcarpet -v 2.3.0
+  sudo /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/gem install pygments.rb
   </code></pre>
-
-  <div class="hint">
-  <h3>WARNING: If you're using a Ruby version manager activate the system Ruby first</h3>
-  <pre><code>
-  rvm use system                          # for RVM
-  expoprt RBENV_VERSION="system"          # for rbenv
-  </code></pre>
-  </div>
 
   </div>
   HTML


### PR DESCRIPTION
Since the system 1.8 version is now required for this bundle, added the explicitly-pathed commands (from the README) to the error dialog. As they're explicitly-pathed, RVM (or rbenv, or any other version manager) isn't relevant, so removed those bits.
