### PR TITLE
Add rb as a shorthand for Ruby

### DIFF
--- a/Syntaxes/Markdown Redcarpet.tmLanguage
+++ b/Syntaxes/Markdown Redcarpet.tmLanguage
@@ -231,7 +231,7 @@
 				<key>fenced_block_ruby</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)([`]{3})[ ]*ruby$</string>
+					<string>(^|\G)([`]{3})[ ]*(?:rb|ruby)$</string>
 					<key>end</key>
 					<string>(^|\G)([`]{3})($|\z)</string>
 					<key>name</key>


### PR DESCRIPTION
This is a just a simple little adjustments that let's you use `rb` in addition to `ruby` in fenced code blocks. `rb` is supported in Github-Flavored Markdown.
