### PR TITLE
Support for Yosemite

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,8 @@ cd ~/Library/Application\ Support/Avian/Bundles/
 git clone https://github.com/streeter/markdown-redcarpet.tmbundle.git
 
 # Then, make sure you've got `redcarpet` and `pygments.rb`
-# installed with your gem library with system's Ruby 1.8:
-unset GEM_HOME
-unset GEM_PATH
-
-sudo /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/gem install redcarpet -v 2.3.0
-sudo /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/gem install pygments.rb
+# installed with your gem library with system's Ruby:
+sudo /usr/bin/env gem install redcarpet:2.3.0 pygments.rb
 ```
 
 ![Redcarpet Markdown Bundle in action](http://cl.ly/image/1Y071W2A2l1w/Screen%20Shot%202014-02-18%20at%2011.02.32%20am.png)

--- a/Support/bin/redcarpet.rb
+++ b/Support/bin/redcarpet.rb
@@ -26,11 +26,7 @@ rescue LoadError
   <h2>Please install the following gems on your system Ruby</h2>
 
   <pre><code>
-  unset GEM_HOME
-  unset GEM_PATH
-
-  sudo /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/gem install redcarpet -v 2.3.0
-  sudo /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/gem install pygments.rb
+  sudo /usr/bin/env gem install redcarpet:2.3.0 pygments.rb
   </code></pre>
 
   </div>

--- a/Support/bin/redcarpet.rb
+++ b/Support/bin/redcarpet.rb
@@ -1,4 +1,4 @@
-#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby
+#!/usr/bin/env ruby
 
 # Usage: redcarpet [<file>...]
 # Convert one or more Markdown files to HTML and write to standard output. With


### PR DESCRIPTION
Trying to fix https://github.com/streeter/markdown-redcarpet.tmbundle/issues/17.

The missing gems have to be installed as follows:

```bash
# bash
sudo /usr/bin/env gem install redcarpet:2.3.0 pygments.rb
```

Since I don't know why originally `/System/Library/Frameworks/Ruby.framework/Versions/1.8` has been used, please double check this change.

It works fine for my Yosemite system (screenshot below).
But, I had to **deactivate the original markdown bundle** in textmate.

Thanks for your bundle!
 
![bildschirmfoto 2015-02-25 um 09 38 36](https://cloud.githubusercontent.com/assets/1679688/6367397/e4fa29b8-bcd2-11e4-9feb-7e76a39adc75.png)
