### PR TITLE
Update commands for Yosemite

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ First, put this bundle in your TextMate bundle directory:
 
 ```bash
 # Textmate2
-mkdir -p ~/Library/Application\ Support/Avian/Bundles/
-cd ~/Library/Application\ Support/Avian/Bundles/
+cd ~/Library/Application Support/TextMate/Managed/Bundles
 git clone https://github.com/streeter/markdown-redcarpet.tmbundle.git
 
 # Then, make sure you've got `redcarpet` and `pygments.rb`
@@ -13,8 +12,8 @@ git clone https://github.com/streeter/markdown-redcarpet.tmbundle.git
 unset GEM_HOME
 unset GEM_PATH
 
-sudo /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/gem install redcarpet -v 2.3.0
-sudo /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/gem install pygments.rb
+sudo /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/bin/gem install redcarpet -v 2.3.0
+sudo /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/bin/gem install pygments.rb
 ```
 
 ![Redcarpet Markdown Bundle in action](http://cl.ly/image/1Y071W2A2l1w/Screen%20Shot%202014-02-18%20at%2011.02.32%20am.png)


### PR DESCRIPTION
It would probably be easiest to make an install script for this, but as-is this is what worked on my Yosemite system for TextMate version 2.0-beta.7.4.