### PR TITLE
Fix grammar captures: markup.raw.inline.markdown

### DIFF
--- a/Syntaxes/Markdown Redcarpet.tmLanguage
+++ b/Syntaxes/Markdown Redcarpet.tmLanguage
@@ -1371,6 +1371,8 @@
 						<key>2</key>
 						<dict/>
 						<key>3</key>
+						<dict/>
+						<key>4</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.raw.markdown</string>


### PR DESCRIPTION
Rather than highlighting the last backtick (“`”), I was seeing the preceding character highlighted instead.  This corrects the issue.  (I used <kbd>^⇧P</kbd> to determine that the `captures` was the issue.)
